### PR TITLE
Add `serve weave()` to update and serve weave files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Weave = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
 
 [compat]
 Crayons = "^4.0.0"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,7 @@ Open a Browser and go to `http://localhost:8000/` to see the content being rende
 
 ### Serve docs
 
-A function derived from `serve` that will be convenient to Julia package developpers is `servedocs`. It runs [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) along with `LiveServer` to render your docs and will track and render any modifications to your docs.
+A function derived from `serve` that will be convenient to Julia package developers is `servedocs`. It runs [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) along with `LiveServer` to render your docs and will track and render any modifications to your docs.
 This instantaneous feedback makes writing docs significantly easier and faster.
 
 Assuming you are in `directory/to/YourPackage.jl` and that you have a `docs/` folder as prescribed by `Documenter`, just run:
@@ -51,6 +51,10 @@ Open a browser and go to `http://localhost:8000/` to see your docs being rendere
 
 You can also use LiveServer with both Documenter and [Literate.jl](https://github.com/fredrikekre/Literate.jl).
 This is explained [here](man/ls+lit.md).
+
+### Serve Weave
+
+The function [`serveweave()`](@ref) monitors for changes to a specified [Weave.jl](https://github.com/JunoLab/Weave.jl), and executes `weave` on that file, also triggering a browser reload. Thus, as with `servedocs`, this function is convenient as a instantaneous "preview" of the Weave file.
 
 ## How it works
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -54,7 +54,7 @@ This is explained [here](man/ls+lit.md).
 
 ### Serve Weave
 
-The function [`serveweave()`](@ref) monitors for changes to a specified [Weave.jl](https://github.com/JunoLab/Weave.jl), and executes `weave` on that file, also triggering a browser reload. Thus, as with `servedocs`, this function is convenient as a instantaneous "preview" of the Weave file.
+The function [`serveweave()`](@ref) monitors for changes to a specified [Weave.jl](https://github.com/JunoLab/Weave.jl), and executes `weave` on that file, also triggering a browser reload. Thus, as with `servedocs`, this function is convenient as an instantaneous "preview" of the Weave file.
 
 ## How it works
 

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -5,4 +5,5 @@ Documentation for `LiveServer.jl`'s exported functions
 ```@docs
 LiveServer.serve
 LiveServer.servedocs
+LiveServer.serveweave
 ```

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -4,8 +4,9 @@ module LiveServer
 using Sockets, Pkg
 # the only dependency (see the patch in http_patch.jl)
 using HTTP
+import Weave
 
-export serve, servedocs
+export serve, servedocs, serveweave
 
 #
 # Environment variables
@@ -33,7 +34,7 @@ const WS_INTERRUPT = Base.Ref{Bool}(false)
 include("mimetypes.jl")
 include("file_watching.jl")
 include("server.jl")
-
 include("utils.jl")
+include("weave.jl")
 
 end # module

--- a/src/weave.jl
+++ b/src/weave.jl
@@ -1,0 +1,44 @@
+"""
+    serveweave(file::AbstractString; port=8080, verbose=false, kwargs...)
+
+Track changes to Weave file `file` (usually with a "jmd" extension) and run the
+command `weave(kwargs...)`, followed by a browser reload.
+
+Except the the keyword arguments specified above, all other keyword arguments
+are passed directly to `weave`. Thus, use `serveweave` exactly as you would
+`weave`.
+
+`serveweave` is only meant to substitute for `weave` when the latter is being
+used for producing html output.
+
+# Example
+
+```julia
+using Weave, Liveserver
+serveweave('example.jmd', cache=:user, port=8080)
+```
+and then point a browser to the url `http://localhost:8080/example.html`.
+"""
+function serveweave(file::AbstractString;
+                    port::Int=8000,
+                    verbose::Bool=false,
+                    weaveargs...)
+    dw = SimpleWatcher(fp->weave_callback!(fp; weaveargs...))
+    push!(dw.watchedfiles, WatchedFile(file))
+    htmlfile = splitext(file)[1]*".html"
+    push!(dw.watchedfiles, WatchedFile(htmlfile))
+    serve(dw, verbose=verbose)
+    return nothing
+end
+
+"""
+Run `weave` anytime that `fp`, but only execute the page-reload callback if
+Weave's html output changes.
+"""
+function weave_callback!(fp; kwargs...)
+    Weave.weave(fp; kwargs...)
+    if endswith(fp, ".html")
+        file_changed_callback(fp)
+    end
+    return nothing
+end


### PR DESCRIPTION
This is a small extension to LiveServer.jl so that it can be easily used for serving [Weave.jl](https://github.com/JunoLab/Weave.jl) files.