### PR TITLE
Call include with absolute path

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -147,7 +147,7 @@ function servedocs(; verbose::Bool=false, literate::String="",
         Pkg.activate("$foldername/Project.toml")
     end
     # trigger a first pass of Documenter (& possibly Literate)
-    Main.include(makejl)
+    Main.include(abspath(makejl))
 
     # note the `docs/build` exists here given that if we're here it means the documenter
     # pass did not error and therefore that a docs/build has been generated.


### PR DESCRIPTION
Workaround for #115: pass absolute path of the `make.jl` file to the `include()`