### PR TITLE
host and port kwargs for servedocs

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -122,6 +122,8 @@ assumed that they are in `docs/src`.
 * `skip_dirs=[]` same as `skip_dir`  but for a vector of such dirs. Takes precedence over `skip_dir`.
 * `foldername="docs"` specify the name of the content folder if different than "docs".
 * `buildfoldername="build"` specify the name of the build folder if different than "build".
+* `host="127.0.0.1"` where the server will start.
+* `port` is an integer between 8000 (default) and 9000.
 * `launch_browser=false` specifies whether to launch the ambient browser at the localhost URL or not.
 """
 function servedocs(; verbose::Bool=false, literate::String="",
@@ -129,6 +131,7 @@ function servedocs(; verbose::Bool=false, literate::String="",
                      skip_dirs::Vector{String}=String[],
                      foldername::String="docs",
                      buildfoldername::String="build",
+                     host::String="127.0.0.1", port::Int=8000,
                      launch_browser::Bool = false)
     # Custom file watcher: it's the standard `SimpleWatcher` but with a custom callback.
     docwatcher = SimpleWatcher()
@@ -151,7 +154,7 @@ function servedocs(; verbose::Bool=false, literate::String="",
 
     # note the `docs/build` exists here given that if we're here it means the documenter
     # pass did not error and therefore that a docs/build has been generated.
-    serve(docwatcher, dir=joinpath(foldername, buildfoldername), verbose=verbose, launch_browser=launch_browser)
+    serve(docwatcher, host=host, port=port, dir=joinpath(foldername, buildfoldername), verbose=verbose, launch_browser=launch_browser)
     if doc_env
         Pkg.activate()
     end


### PR DESCRIPTION
`servedocs` doesn't have these kwargs, maybe it should just as `serve`?