### PR TITLE
Use WSS protocol when accessing LiveServer over HTTPS

### DIFF
--- a/src/client.html
+++ b/src/client.html
@@ -1,6 +1,6 @@
 <!-- browser-reload script, automatically added by the LiveServer.jl -->
 <script>
-var ws_liveserver_M3sp9 = new WebSocket("ws://" + location.host + location.pathname);
+var ws_liveserver_M3sp9 = new WebSocket((location.protocol=="https:" ? "wss:" : "ws:") + "//" + location.host + location.pathname);
 ws_liveserver_M3sp9.onmessage = function(msg) {
     if (msg.data === "update") {
         ws_liveserver_M3sp9.close();


### PR DESCRIPTION
Hi,

and first let me thank you for `LiveServer`: it is really useful!

I noticed that live-reload fails when LiveServer is put behind a proxy and accessed over HTTPS. Chrome for example, fails with the following error message:
```
Uncaught DOMException: Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.
```

It looks like this can be fixed by simply using the WSS protocol when accessing the page over HTTPS, and WS otherwise. This is what's implemented in this PR.

PS: I'm not sure whether this is related to #2 
P²S: I'm way outside my area of expertise here; please forgive me if this is mostly noise...