### PR TITLE
Add trigger compilation flag to serve

### DIFF
--- a/test/server.jl
+++ b/test/server.jl
@@ -65,6 +65,13 @@ tasks that you will try to start.
     #
     # STEP 2: triggering a request
     #
+    url = "http://localhost:$port/"
+
+    # Using allocations to test `trigger_compilation` because it is more robust than runtime.
+    sleep(8)
+    allocations = @allocated HTTP.get(url)
+    @test allocations < 100_000_000
+
     response = HTTP.get("http://localhost:$port/")
     @test response.status == 200
     # the browser script should be appended


### PR DESCRIPTION
@tlienart this implements the thing I was talking about on Slack. See also https://github.com/JuliaWeb/HTTP.jl/pull/720 for a previous discussion.

Give this PR a very **critical** review please. For me, this would be a great addition making me life a bit better. However, I'm also aware that it is quite a hacky solution.

Also, notice that this is sort of breaking since it defaults to yes. I don't think that it would break any user configuration, but maybe it requires a breaking release. 