### PR TITLE
Fix isfile failure issue

### DIFF
--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -24,7 +24,10 @@ Check if a `WatchedFile` has changed. Returns -1 if the file does not exist, 0 i
 has not changed, and 1 if it has changed.
 """
 function has_changed(wf::WatchedFile)
-    isfile(wf.path) || return -1
+    if !isfile(wf.path)
+      sleep(0.1)
+      isfile(wf.path) || return -1
+    end
     return Int(mtime(wf.path) > wf.mtime)
 end
 

--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -25,8 +25,11 @@ has not changed, and 1 if it has changed.
 """
 function has_changed(wf::WatchedFile)
     if !isfile(wf.path)
-      sleep(0.1)
-      isfile(wf.path) || return -1
+        # isfile may return false for a file
+        # currently being written. Wait for 0.1s 
+        # then retry once more:
+        sleep(0.1)
+        isfile(wf.path) || return -1
     end
     return Int(mtime(wf.path) > wf.mtime)
 end


### PR DESCRIPTION
We are using LiveServer in a project and are finding that sometimes it will think a file is missing, when it fact it is just in the process of being updated (e.g. overwritten by a text editor). This is happening on MacOS version 12. This PR adds a second check after an initial failure of `isfile` which happens 0.1s later before the file is declared missing. If the file is found by the first call to `isfile`, there is no second call.

Of course, please let me know if you think a different approach to this issue would be better.
