### PR TITLE
add file server page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,21 @@ julia> serve() # starts the local server & the file watching
 
 Open a Browser and go to `http://localhost:8000/` to see the content being rendered; try modifying files (e.g. `index.html`) and watch the changes being rendered immediately in the browser.
 
+In the REPL:
 ```julia-repl
 julia> using LiveServer
 julia> serve(host="0.0.0.0", port=8001, dir=".") # starts the remote server & the file watching
 ✓ LiveServer listening on http://0.0.0.0:8001...
   (use CTRL+C to shut down)
 ```
+In the terminal:
 ```julia-repl
-julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'
-such as: 
-python3 -m http.server 8001
+julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'  # like as: python -m http.server 8001
 ```
 
-Open a Browser and go to `http://remote_ip:8001/` to see the remote host file list; You can set dir="you/want/share/path" to show file list as file server. You can set port to custom. It's function same as Python's [`http.server`](https://docs.python.org/3/library/http.server.html)
+Open a browser and go to https://localhost:8001/ to see the rendered content of index.html or, if it doesn't exist, the content of the directory.
+You can set the port to a custom number.
+This is similar to the [`http.server`](https://docs.python.org/3/library/http.server.html) in Python.
 
 ### Serve docs
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ julia> serve() # starts the local server & the file watching
 
 Open a Browser and go to `http://localhost:8000/` to see the content being rendered; try modifying files (e.g. `index.html`) and watch the changes being rendered immediately in the browser.
 
+```julia-repl
+julia> using LiveServer
+julia> serve(host="0.0.0.0", port=8001, dir=".") # starts the remote server & the file watching
+✓ LiveServer listening on http://0.0.0.0:8001...
+  (use CTRL+C to shut down)
+```
+```julia-repl
+julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'
+such as: 
+python3 -m http.server 8001
+```
+
+Open a Browser and go to `http://remote_ip:8001/` to see the remote host file list; You can set dir="you/want/share/path" to show file list as file server. You can set port to custom. It's function same as Python's [`http.server`](https://docs.python.org/3/library/http.server.html)
+
 ### Serve docs
 
 `servedocs` is a convenience function that runs `Documenter` along with `LiveServer` to watch your doc files for any changes and render them in your browser when modifications are detected.  

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,19 +29,21 @@ julia> serve() # starts the local server & the file watching
 
 Open a Browser and go to `http://localhost:8000/` to see the content being rendered; try modifying files (such as `index.html`) and watch the changes being rendered immediately in the browser.
 
+In the REPL:
 ```julia-repl
 julia> using LiveServer
 julia> serve(host="0.0.0.0", port=8001, dir=".") # starts the remote server & the file watching
 ✓ LiveServer listening on http://0.0.0.0:8001...
   (use CTRL+C to shut down)
 ```
+In the terminal:
 ```julia-repl
-julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'
-such as: 
-python3 -m http.server 8001
+julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'  # like as: python -m http.server 8001
 ```
 
-Open a Browser and go to `http://remote_ip:8001/` to see the remote host file list; You can set dir="you/want/share/path" to show file list as file server. You can set port to custom. It's function same as Python's [`http.server`](https://docs.python.org/3/library/http.server.html)
+Open a browser and go to https://localhost:8001/ to see the rendered content of index.html or, if it doesn't exist, the content of the directory.
+You can set the port to a custom number.
+This is similar to the [`http.server`](https://docs.python.org/3/library/http.server.html) in Python.
 
 ### Serve docs
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,10 +31,16 @@ Open a Browser and go to `http://localhost:8000/` to see the content being rende
 
 ```julia-repl
 julia> using LiveServer
-julia> serve(host="0.0.0.0", port=8001, dir=".", verbose=true) # starts the remote server & the file watching
+julia> serve(host="0.0.0.0", port=8001, dir=".") # starts the remote server & the file watching
 ✓ LiveServer listening on http://0.0.0.0:8001...
   (use CTRL+C to shut down)
 ```
+```julia-repl
+julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'
+such as: 
+python3 -m http.server 8001
+```
+
 Open a Browser and go to `http://remote_ip:8001/` to see the remote host file list; You can set dir="you/want/share/path" to show file list as file server. You can set port to custom. It's function same as Python's [`http.server`](https://docs.python.org/3/library/http.server.html)
 
 ### Serve docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,6 +29,14 @@ julia> serve() # starts the local server & the file watching
 
 Open a Browser and go to `http://localhost:8000/` to see the content being rendered; try modifying files (such as `index.html`) and watch the changes being rendered immediately in the browser.
 
+```julia-repl
+julia> using LiveServer
+julia> serve(host="0.0.0.0", port=8001, dir=".", verbose=true) # starts the remote server & the file watching
+✓ LiveServer listening on http://0.0.0.0:8001...
+  (use CTRL+C to shut down)
+```
+Open a Browser and go to `http://remote_ip:8001/` to see the remote host file list; You can set dir="you/want/share/path" to show file list as file server. You can set port to custom. It's function same as Python's [`http.server`](https://docs.python.org/3/library/http.server.html)
+
 ### Serve docs
 
 A function derived from `serve` that will be convenient to Julia package developpers is `servedocs`. It runs [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) along with `LiveServer` to render your docs and will track and render any modifications to your docs.

--- a/src/server.jl
+++ b/src/server.jl
@@ -118,7 +118,6 @@ function get_dir_list(dir::AbstractString)
         list = readdir(path; join=false, sort=true)
     end
     io = IOBuffer()
-    enc = "utf-8"  # sys.getfilesystemencoding()
     title = "Directory listing for $(dir)"
     write(io, """
         <!DOCTYPE HTML>
@@ -142,7 +141,7 @@ function get_dir_list(dir::AbstractString)
             <li><a href="$(linkname)">$(displayname)</a></li>
             """
         )
-        empty!(list)
+        list = []
     end
 
     for name in list

--- a/src/server.jl
+++ b/src/server.jl
@@ -121,20 +121,28 @@ function get_dir_list(dir::AbstractString)
     enc = "utf-8"  # sys.getfilesystemencoding()
     title = "Directory listing for $(dir)"
     write(io, """
-    <!DOCTYPE HTML>
-    <html>
-     <head>
-    """)
-    write(io, """<meta http-equiv="Content-Type" content="text/html; charset=$(enc)">""")
-    write(io, """<title>$(title)</title>\n</head>""")
-    write(io, """<body>\n<h1>$(title)</h1>""")
-    write(io, """<hr>\n<ul>""")
+        <!DOCTYPE HTML>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>$(title)</title>
+          </head>
+          <body>
+            <h1>$(title)</h1>
+            <hr>
+            <ul>
+        """
+    )
 
     if isfile(path)
         linkname = path
         displayname = basename(path)
-        write(io, """<li><a href="$(linkname)">$(displayname)</a></li>""")
-        list = []
+        write(io, """
+            <li><a href="$(linkname)">$(displayname)</a></li>
+            """
+        )
+        empty!(list)
     end
 
     for name in list
@@ -149,12 +157,19 @@ function get_dir_list(dir::AbstractString)
             displayname = name * "@"
             # Note: a link to a directory displays with @ and links with /
         end
-        write(io, """<li><a href="$(linkname)">$(displayname)</a></li>""")
+        write(io, """
+            <li><a href="$(linkname)">$(displayname)</a></li>
+            """
+        )
     end
-    write(io, """</ul>\n<hr>\n</body>\n</html>\n""")
-    index_page = take!(io)
-
-    return index_page
+    write(io, """
+            </ul>
+            <hr>
+          </body>
+        </html>
+        """
+    )
+    return String(take!(io))
 end
 
 """

--- a/src/server.jl
+++ b/src/server.jl
@@ -114,7 +114,6 @@ Get dir list of current path. generate a index page html.
 target is current dir path.
 """
 function get_dir_list(target::AbstractString)
-    println("===========:", joinpath(abspath(CONTENT_DIR[]), target[2:end]))
     path = joinpath(abspath(CONTENT_DIR[]), target[2:end])
     if isdir(path)
         list = readdir(path; join=false, sort=true)
@@ -183,9 +182,8 @@ function serve_file(fw, req::HTTP.Request; inject_browser_reload_script::Bool = 
         end
         # If still not found a body, return a generic error message
         if isempty(fs_path)
-            # println("aaaaaa:", CONTENT_DIR[], ", ", req.target, ", ", abspath(CONTENT_DIR[]))
-            encoded = get_dir_list(req.target)  # 基本实现功能
-            return HTTP.Response(200, encoded)
+            index_page = get_dir_list(req.target)  # 基本实现功能
+            return HTTP.Response(200, index_page)
             # return HTTP.Response(404, "404: file not found. Perhaps you made a typo " *
             #                           "in the URL, or the requested file has been " *
             #                           "deleted or renamed.")

--- a/src/server.jl
+++ b/src/server.jl
@@ -182,7 +182,7 @@ function serve_file(fw, req::HTTP.Request; inject_browser_reload_script::Bool = 
         end
         # If still not found a body, return a generic error message
         if isempty(fs_path)
-            index_page = get_dir_list(req.target)  # 基本实现功能
+            index_page = get_dir_list(req.target)
             return HTTP.Response(200, index_page)
             # return HTTP.Response(404, "404: file not found. Perhaps you made a typo " *
             #                           "in the URL, or the requested file has been " *


### PR DESCRIPTION
```julia-repl
julia> using LiveServer
julia> serve(host="0.0.0.0", port=8001, dir=".") # starts the remote server & the file watching
✓ LiveServer listening on http://0.0.0.0:8001...
  (use CTRL+C to shut down)
```
```julia-repl
julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'
such as: 
python3 -m http.server 8001
```

Open a Browser and go to `http://remote_ip:8001/` to see the remote host file list; You can set dir="you/want/share/path" to show file list as file server. You can set port to custom. It's function same as Python's [`http.server`](https://docs.python.org/3/library/http.server.html)

such as: 
![image](https://user-images.githubusercontent.com/12711073/156965959-771e3e11-5666-4f18-9491-5deeb9e8bb29.png)

