### PR TITLE
bringing in http1 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "0.10.0"
+version = "1.0.0"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "0.9.2"
+version = "0.10.0"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
@@ -14,6 +14,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Crayons = "4"
-HTTP = "0.8, 0.9"
+HTTP = "1"
 MIMEs = "0.1"
-julia = "1.3"
+julia = "1.6"

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -26,18 +26,6 @@ const WS_VIEWERS = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()
 """Keep track of whether an interruption happened while processing a websocket."""
 const WS_INTERRUPT = Base.Ref{Bool}(false)
 
-# to fix lots of false error messages from HTTP
-# https://github.com/JuliaWeb/HTTP.jl/pull/546
-# we do HTTP.Stream{HTTP.Messages.Request,S} instead of just HTTP.Stream to prevent the Julia warning about incremental compilation
-# This hack was kindly suggested by Fons van der Plas, the author of Pluto.jl see
-# https://github.com/fonsp/Pluto.jl/commit/34d41e63138ee6dad178cd9916d4721441eaf710
-function HTTP.closebody(http::HTTP.Stream{HTTP.Messages.Request,S}) where S <: IO
-    http.writechunked || return
-    http.writechunked = false
-    try; write(http.stream, "0\r\n\r\n"); catch; end
-    return
-end
-
 #
 # Functions
 #

--- a/src/client.html
+++ b/src/client.html
@@ -1,6 +1,8 @@
 <!-- browser-reload script, automatically added by the LiveServer.jl -->
 <script>
-var ws_liveserver_M3sp9 = new WebSocket((location.protocol=="https:" ? "wss:" : "ws:") + "//" + location.host + location.pathname);
+var ws_liveserver_M3sp9 = new WebSocket(
+        (location.protocol=="https:" ? "wss:" : "ws:") + "//" + location.host + location.pathname
+    );
 ws_liveserver_M3sp9.onmessage = function(msg) {
     if (msg.data === "update") {
         ws_liveserver_M3sp9.close();

--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -26,7 +26,7 @@ has not changed, and 1 if it has changed.
 function has_changed(wf::WatchedFile)
     if !isfile(wf.path)
         # isfile may return false for a file
-        # currently being written. Wait for 0.1s 
+        # currently being written. Wait for 0.1s
         # then retry once more:
         sleep(0.1)
         isfile(wf.path) || return -1
@@ -111,8 +111,8 @@ function file_watcher_task!(fw::FileWatcher)
     catch err
         fw.status = :interrupted
         # an InterruptException is the normal way for this task to end
-        if !isa(err, InterruptException)
-            error("An error happened whilst watching files; shutting down. Error was: $err")
+        if !isa(err, InterruptException) && VERBOSE[]
+            @error "fw error" exception=(err, catch_backtrace())
         end
         return nothing
     end

--- a/src/server.jl
+++ b/src/server.jl
@@ -370,7 +370,7 @@ function ws_tracker(ws::HTTP.WebSockets.WebSocket)
         # See update_and_close_viewers
         while !ws.writeclosed && isopen(ws.io)
             WebSockets.ping(ws)
-            sleep(1.0)
+            sleep(0.1)
         end
     catch err
         # NOTE: there may be several sources of errors caused by the precise moment

--- a/src/server.jl
+++ b/src/server.jl
@@ -519,7 +519,7 @@ directory. (See also [`example`](@ref) for an example folder).
         # empty the dictionary of viewers
         empty!(WS_VIEWERS)
         # shut down the server
-        close(server)
+        HTTP.Servers.forceclose(server)
         # reset environment variables
         CONTENT_DIR[]  = ""
         WS_INTERRUPT[] = false

--- a/src/server.jl
+++ b/src/server.jl
@@ -437,7 +437,7 @@ directory. (See also [`example`](@ref) for an example folder).
              host::String = "127.0.0.1",
              port::Int = 8000,
              dir::AbstractString = "",
-             verbose::Bool = true,
+             verbose::Bool = false,
              coreloopfun::Function = (c, fw)->nothing,
              preprocess_request::Function = identity,
              inject_browser_reload_script::Bool = true,

--- a/src/server.jl
+++ b/src/server.jl
@@ -357,11 +357,11 @@ function ws_tracker(ws::HTTP.WebSockets.WebSocket)
 
     # start an async task to receive messages from ws and ignore them
     # this allows reading pongs and close frames from the browser
-    errormonitor(@async begin
+    @async begin
         for msg in ws
             # pass
         end
-    end)
+    end
 
     try
         # NOTE: browsers will drop idle websocket connections so this effectively

--- a/src/server.jl
+++ b/src/server.jl
@@ -38,9 +38,12 @@ closing anyway and clients will re-connect from the re-loaded page.
 function update_and_close_viewers!(wss::Vector{HTTP.WebSockets.WebSocket})
     foreach(wss) do wsi
         try
-            write(wsi, "update")
+            send(wsi, "update")
             close(wsi)
-        catch
+        catch e
+            if VERBOSE[]
+                 @error "update_and_close_viewers! error" exception=(e, catch_backtrace())
+            end
         end
     end
     empty!(wss)
@@ -331,53 +334,43 @@ function serve_file(
     return resp
 end
 
-"""
-    ws_upgrade(http::HTTP.Stream)
-
-Upgrade the HTTP request in the stream to a websocket.
-"""
-function ws_upgrade(http::HTTP.Stream)
-    # adapted from HTTP.WebSockets.upgrade; note that here the upgrade will always
-    # have  the right format as it always triggered by after a Response
-    HTTP.setstatus(http, 101)
-    HTTP.setheader(http, "Upgrade" => "websocket")
-    HTTP.setheader(http, "Connection" => "Upgrade")
-    key = HTTP.header(http, "Sec-WebSocket-Key")
-    HTTP.setheader(http, "Sec-WebSocket-Accept" => HTTP.WebSockets.accept_hash(key))
-    HTTP.startwrite(http)
-
-    io = http.stream
-    return HTTP.WebSockets.WebSocket(io; server=true)
-end
-
 
 """
     ws_tracker(ws::HTTP.WebSockets.WebSocket, target::AbstractString)
 
-Adds the websocket connection to the viewers in the global dictionary `WS_VIEWERS` to the entry
-corresponding to the targeted file.
+Adds the websocket connection to the viewers in the global dictionary
+`WS_VIEWERS` to the entry corresponding to the targeted file.
 """
-function ws_tracker(ws::HTTP.WebSockets.WebSocket, target::AbstractString)
-    # add to list of html files being "watched"
+function ws_tracker(ws::HTTP.WebSockets.WebSocket)
+    target = ws.request.target
     # NOTE: this file always exists because the query is generated just after
     # serving it
     fs_path = get_fs_path(target)
 
-    # if the file is already being viewed, add ws to it (e.g. several tabs)
-    # otherwise add to dict
-    if fs_path ∈ keys(WS_VIEWERS)
+    # add to list of html files being "watched" if the file is already being
+    # viewed, add ws to it (e.g. several tabs) otherwise add to dict
+    if haskey(WS_VIEWERS, fs_path)
         push!(WS_VIEWERS[fs_path], ws)
     else
         WS_VIEWERS[fs_path] = [ws]
     end
+
+    # start an async task to receive messages from ws and ignore them
+    # this allows reading pongs and close frames from the browser
+    errormonitor(@async begin
+        for msg in ws
+            # pass
+        end
+    end)
 
     try
         # NOTE: browsers will drop idle websocket connections so this effectively
         # forces the websocket to stay open until it's closed by LiveServer (and
         # not by the browser) upon writing a `update` message on the websocket.
         # See update_and_close_viewers
-        while isopen(ws.io)
-            sleep(0.1)
+        while !ws.writeclosed && isopen(ws.io)
+            WebSockets.ping(ws)
+            sleep(1.0)
         end
     catch err
         # NOTE: there may be several sources of errors caused by the precise moment
@@ -389,7 +382,12 @@ function ws_tracker(ws::HTTP.WebSockets.WebSocket, target::AbstractString)
         # - We therefore do not propagate the error but merely store the information
         # that there was a forcible interruption of the websocket so that the
         # interruption can be guaranteed to be propagated.
-        WS_INTERRUPT[] = true
+        if !WebSockets.isok(err)
+            if VERBOSE[]
+                @error "ws_tracker error" exception=(err, catch_backtrace())
+            end
+            WS_INTERRUPT[] = true
+        end
     end
     return nothing
 end
@@ -463,7 +461,7 @@ directory. (See also [`example`](@ref) for an example folder).
     start(fw)
 
     # make request handler
-    req_handler = HTTP.RequestHandlerFunction() do req
+    req_handler = HTTP.Handlers.streamhandler() do req
         req = preprocess_request(req)
         serve_file(
             fw, req;
@@ -472,31 +470,19 @@ directory. (See also [`example`](@ref) for an example folder).
         )
     end
 
-    server = Sockets.listen(parse(IPAddr, host), port)
-    url = "http://$(host == string(Sockets.localhost) ? "localhost" : host):$port"
+    server, port = get_server(host, port, req_handler)
+    host_str     = ifelse(host == string(Sockets.localhost), "localhost", host)
+    url          = "http://$host_str:$port"
     println(
         "✓ LiveServer listening on $url/ ...\n  (use CTRL+C to shut down)"
     )
-    @async HTTP.listen(host, port;
-                       server=server, readtimeout=0, reuse_limit=0) do http::HTTP.Stream
-        # reuse_limit=0 ensures that there won't be an error if killing and restarting the server.
-        if HTTP.WebSockets.is_upgrade(http.message)
-            # upgrade to websocket
-            ws = ws_upgrade(http)
-            # add to list of viewers and keep open until written to
-            ws_tracker(ws, http.message.target)
-        else
-            # handle HTTP request
-            HTTP.handle(req_handler, http)
-        end
-    end
 
     launch_browser && open_in_default_browser(url)
     # wait until user interrupts the LiveServer (using CTRL+C).
     try
         counter = 1
         while true
-            if WS_INTERRUPT.x || fw.status == :interrupted
+            if WS_INTERRUPT[] || fw.status == :interrupted
                 # rethrow the interruption (which may have happened during
                 # the websocket handling or during the file watching)
                 throw(InterruptException())
@@ -509,6 +495,9 @@ directory. (See also [`example`](@ref) for an example folder).
         end
     catch err
         if !isa(err, InterruptException)
+            if VERBOSE[]
+                @error "serve error" exception=(err, catch_backtrace())
+            end
             throw(err)
         end
     finally
@@ -518,7 +507,7 @@ directory. (See also [`example`](@ref) for an example folder).
         stop(fw)
         # close any remaining websockets
         for wss ∈ values(WS_VIEWERS), wsi ∈ wss
-            close(wsi.io)
+            close(wsi)
         end
         # empty the dictionary of viewers
         empty!(WS_VIEWERS)
@@ -526,8 +515,28 @@ directory. (See also [`example`](@ref) for an example folder).
         close(server)
         VERBOSE[] && println("\n✓ LiveServer shut down.")
         # reset environment variables
-        CONTENT_DIR[] = ""
+        CONTENT_DIR[]  = ""
         WS_INTERRUPT[] = false
     end
     return nothing
+end
+
+function get_server(host, port, req_handler; incr=0)
+    if incr >= 10
+        @error "couldn't find a free port in $incr tries"
+    end
+    try
+        server = HTTP.listen!(host, port; readtimeout=0) do http::HTTP.Stream
+            if HTTP.WebSockets.isupgrade(http.message)
+                # upgrade to websocket and add to list of viewers and keep open until written to
+                HTTP.WebSockets.upgrade(ws_tracker, http)
+            else
+                # handle HTTP request
+                return req_handler(http)
+            end
+        end
+        return server, port
+    catch IOError
+        return get_server(host, port+1, req_handler; incr=incr+1)
+    end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -252,7 +252,7 @@ end
 
 Set the verbosity of LiveServer to either `true` (showing messages upon events) or `false` (default).
 """
-setverbose(b::Bool) = (VERBOSE.x = b)
+setverbose(b::Bool) = (VERBOSE[] = b)
 
 
 """

--- a/test/server.jl
+++ b/test/server.jl
@@ -220,7 +220,6 @@ end
     @test LS.WS_INTERRUPT[]
 
     @test length(LS.WS_VIEWERS[fs_path]) == 2
-    @test LS.WS_VIEWERS[fs_path][2] == ws
 
     # cleanup
     close(server)

--- a/test/server.jl
+++ b/test/server.jl
@@ -103,14 +103,16 @@ tasks that you will try to start.
     # our own sentinel websocket
     function makews()
         req = HTTP.Request()
-        return HTTP.WebSockets.WebSocket(HTTP.Connection(IOBuffer()), req, req.response; client=false)
+        return HTTP.WebSockets.WebSocket(
+            HTTP.Connection(IOBuffer()), req, req.response; client=false
+        )
     end
     sentinel = makews()
     LS.WS_VIEWERS["tmp.html"] = [sentinel]
 
     @test sentinel.io.io.writable
     write("tmp.html", "something new")
-    sleep(0.1)
+    sleep(0.5)
     # the sentinel websocket should be closed
     @test !sentinel.io.io.writable
     # the websockets should have been flushed
@@ -122,7 +124,7 @@ tasks that you will try to start.
     push!(LS.WS_VIEWERS["tmp.html"], sentinel1)
     LS.WS_VIEWERS["css/foo.css"] = [sentinel2]
     write("css/foo.css", "body { color:blue; }")
-    sleep(0.1)
+    sleep(0.5)
     # all sentinel websockets should be closed
     @test !sentinel1.io.io.writable
     @test !sentinel2.io.io.writable


### PR DESCRIPTION
0.9.2 + #145 , thanks @quinnj and @fredrikekre who did most of the work. I also added some logic to close #139 

I won't merge this before we've had some time to play with it and make sure that we're out of #143 .

It seems to work fine from my checks though the tests lead to an error upon (apparently) calling `close(ws)` in the test block `Server/ws_tracker testing` (actually the test block passes but the error is shown)

Any idea how to clean that up?

```
julia> Unhandled Task ERROR: EOFError: read end of file
Stacktrace:
  [1] (::Base.var"#wait_locked#648")(s::TCPSocket, buf::IOBuffer, nb::Int64)
    @ Base ./stream.jl:892
  [2] unsafe_read(s::TCPSocket, p::Ptr{UInt8}, nb::UInt64)
    @ Base ./stream.jl:900
  [3] unsafe_read(c::HTTP.ConnectionPool.Connection, p::Ptr{UInt8}, n::UInt64)
    @ HTTP.ConnectionPool ~/.julia/packages/HTTP/4Xalq/src/ConnectionPool.jl:173
  [4] unsafe_read
    @ ./io.jl:724 [inlined]
  [5] unsafe_read(s::HTTP.ConnectionPool.Connection, p::Base.RefValue{UInt16}, n::Int64)
    @ Base ./io.jl:723
  [6] read!
    @ ./io.jl:725 [inlined]
  [7] read
    @ ./io.jl:729 [inlined]
  [8] readframe(io::HTTP.ConnectionPool.Connection, ::Type{HTTP.WebSockets.Frame}, buffer::Vector{UInt8}, first_fragment_opcode::HTTP.WebSockets.OpCode)
    @ HTTP.WebSockets ~/.julia/packages/HTTP/4Xalq/src/WebSockets.jl:128
  [9] readframe
    @ ~/.julia/packages/HTTP/4Xalq/src/WebSockets.jl:127 [inlined]
 [10] receive(ws::HTTP.WebSockets.WebSocket)
    @ HTTP.WebSockets ~/.julia/packages/HTTP/4Xalq/src/WebSockets.jl:658
 [11] iterate(ws::HTTP.WebSockets.WebSocket, st::Nothing)
    @ HTTP.WebSockets ~/.julia/packages/HTTP/4Xalq/src/WebSockets.jl:697
 [12] iterate
    @ ~/.julia/packages/HTTP/4Xalq/src/WebSockets.jl:695 [inlined]
 [13] macro expansion
    @ ~/.julia/dev/LiveServer/src/server.jl:361 [inlined]
 [14] (::LiveServer.var"#13#14"{HTTP.WebSockets.WebSocket})()
    @ LiveServer ./task.jl:429
```