### PR TITLE
n-th attempt at fixing 135

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,0 @@
-comment: false
-
-ignore:
-  - "src/precompile.jl"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The LiveServer.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2019: Jonas Asprion, Thibaut Lienart.
+> Copyright (c) 2019-2022: Jonas Asprion, Thibaut Lienart, and collaborators.
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,0 @@
-# News
-
-# version 0.2
-
-* interop with [`Literate.jl`](https://github.com/fredrikekre/Literate.jl); see [the docs](https://asprionj.github.io/LiveServer.jl/dev/man/ls+lit/) for more information ([#71](https://github.com/asprionj/LiveServer.jl/pull/71))
-* improvements to `servedocs` including keyword `verbose` ([#70](https://github.com/asprionj/LiveServer.jl/pull/71))

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,23 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
-Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 MIMEs = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Crayons = "4"
 HTTP = "1"
 MIMEs = "0.1"
 julia = "1.6"
+
+[extras]
+Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Crayons"]

--- a/README.md
+++ b/README.md
@@ -119,3 +119,12 @@ $ julia --project=docs -ie 'using YourPackage, LiveServer; servedocs()'
 
 **Note**: this works with [Literate.jl](https://github.com/fredrikekre/Literate.jl) as well.
 See [the docs](https://tlienart.github.io/LiveServer.jl/dev/man/ls+lit/).
+
+
+## DEV/Path testing
+
+See also issue #135 and related PRs.
+
+* `servedocs()`, navigate to literate, images should show
+* `serve()` navigate manually to `docs/build/` should show, remove trailing slash in URL `docs/build` should redirect to `docs/build/`
+* `serve(dir=...)` should work + when navigating to assets etc

--- a/README.md
+++ b/README.md
@@ -4,17 +4,28 @@
 [![codecov](https://codecov.io/gh/tlienart/LiveServer.jl/branch/master/graph/badge.svg?token=mNry6r2aIn)](https://codecov.io/gh/tlienart/LiveServer.jl)
 [![dev-doc](https://img.shields.io/badge/docs-dev-blue.svg)](https://tlienart.github.io/LiveServer.jl/dev/)
 
-This is a simple and lightweight development web-server written in Julia, based on [HTTP.jl](https://github.com/JuliaWeb/HTTP.jl).
-It has live-reload capability, i.e. when modifying a file, every browser (tab) currently displaying the corresponding page is automatically refreshed.
+This is a simple and lightweight development web-server written in Julia,
+based on [HTTP.jl](https://github.com/JuliaWeb/HTTP.jl).
+It has live-reload capability, i.e. when modifying a file, every browser (tab)
+currently displaying the corresponding page is automatically refreshed.
 
-LiveServer is inspired from Python's [`http.server`](https://docs.python.org/3/library/http.server.html) and Node's [`browsersync`](https://www.browsersync.io/).
+LiveServer is inspired from Python's [`http.server`](https://docs.python.org/3/library/http.server.html)
+and Node's [`browsersync`](https://www.browsersync.io/).
 
 ## Installation
 
-To install it in Julia ≥ 1.3, use the package manager with
+To install it in Julia ≥ 1.6, use the package manager with
 
 ```julia-repl
 pkg> add LiveServer
+```
+
+### Legacy notes
+
+For Julia `< 1.6`, you can use LiveServer's version 0.9.2:
+
+```julia-repl
+pkg> add LiveServer@0.9.2
 ```
 
 For Julia `[1.0, 1.3)`, you can use LiveServer's version 0.7.4:
@@ -25,20 +36,24 @@ pkg> add LiveServer@0.7.4
 
 ### Make it a shell command
 
-LiveServer is a small package and fast to load with one main functionality (`serve`), it can be convenient to make it a shell command: (I'm using the name `lss` here but you could use something else):
+LiveServer is a small package and fast to load with one main functionality (`serve`),
+it can be convenient to make it a shell command: (I'm using the name `lss` here but
+you could use something else):
 
 ```
 alias lss='julia -e "import LiveServer as LS; LS.serve(launch_browser=true)"'
 ```
 
-you can then use `lss` in any directory to show a directory listing in your browser, and if the directory has an `index.html` then that will be rendered in your browser.
+you can then use `lss` in any directory to show a directory listing in your browser,
+and if the directory has an `index.html` then that will be rendered in your browser.
 
 ## Usage
 
-The main function `LiveServer` exports is `serve` which starts listening to the current folder and makes its content available to a browser.
+The main function `LiveServer` exports is `serve` which starts listening to the current
+folder and makes its content available to a browser.
 The following code creates an example directory and serves it:
 
-```julia
+```julia-repl
 julia> using LiveServer
 julia> LiveServer.example() # creates an "example/" folder with some files
 julia> cd("example")
@@ -47,7 +62,8 @@ julia> serve() # starts the local server & the file watching
   (use CTRL+C to shut down)
 ```
 
-Open a Browser and go to `http://localhost:8000/` to see the content being rendered; try modifying files (e.g. `index.html`) and watch the changes being rendered immediately in the browser.
+Open a Browser and go to `http://localhost:8000/` to see the content being rendered;
+try modifying files (e.g. `index.html`) and watch the changes being rendered immediately in the browser.
 
 In the REPL:
 ```julia-repl
@@ -58,21 +74,25 @@ julia> serve(host="0.0.0.0", port=8001, dir=".") # starts the remote server & th
 ```
 
 In the terminal:
-```julia-repl
+```bash
 julia -e 'using LiveServer; serve(host="0.0.0.0", port=8001, dir=".")'
 ```
 
-Open a browser and go to https://localhost:8001/ to see the rendered content of index.html or, if it doesn't exist, the content of the directory.
+Open a browser and go to https://localhost:8001/ to see the rendered content of index.html or,
+if it doesn't exist, the content of the directory.
 You can set the port to a custom number.
 This is similar to the [`http.server`](https://docs.python.org/3/library/http.server.html) in Python.
 
 ### Serve docs
 
-`servedocs` is a convenience function that runs `Documenter` along with `LiveServer` to watch your doc files for any changes and render them in your browser when modifications are detected.  
+`servedocs` is a convenience function that runs `Documenter` along with `LiveServer` to watch
+your doc files for any changes and render them in your browser when modifications are detected.  
 
-Assuming you are in `directory/to/YourPackage.jl`, that you have a `docs/` folder as prescribed by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and `LiveServer` installed in your global environment, you can run:
+Assuming you are in `directory/to/YourPackage.jl`, that you have a `docs/` folder as
+prescribed by [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and `LiveServer`
+installed in your global environment, you can run:
 
-```julia
+```julia-repl
 $ julia
 
 pkg> activate docs
@@ -88,7 +108,8 @@ julia> servedocs()
   (use CTRL+C to shut down)
 ```
 
-Open a browser and go to `http://localhost:8000/` to see your docs being rendered; try modifying files (e.g. `docs/index.md`) and watch the changes being rendered in the browser.
+Open a browser and go to `http://localhost:8000/` to see your docs being rendered;
+try modifying files (e.g. `docs/index.md`) and watch the changes being rendered in the browser.
 
 To run the server with one line of code, run:
 
@@ -96,4 +117,5 @@ To run the server with one line of code, run:
 $ julia --project=docs -ie 'using YourPackage, LiveServer; servedocs()'
 ```
 
-**Note**: this works with [Literate.jl](https://github.com/fredrikekre/Literate.jl) as well. See [the docs](https://tlienart.github.io/LiveServer.jl/dev/man/ls+lit/).
+**Note**: this works with [Literate.jl](https://github.com/fredrikekre/Literate.jl) as well.
+See [the docs](https://tlienart.github.io/LiveServer.jl/dev/man/ls+lit/).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,7 @@ julia> using LiveServer
 julia> LiveServer.example() # creates an "example/" folder with some files
 julia> cd("example")
 julia> serve() # starts the local server & the file watching
-✓ LiveServer listening on http://localhost:8000...
+✓ LiveServer listening on http://localhost:8000/ ...
   (use CTRL+C to shut down)
 ```
 
@@ -45,9 +45,10 @@ Open a browser and go to https://localhost:8001/ to see the rendered content of 
 You can set the port to a custom number.
 This is similar to the [`http.server`](https://docs.python.org/3/library/http.server.html) in Python.
 
-### Serve docs
+### Live serve your docs
 
-A function derived from `serve` that will be convenient to Julia package developpers is `servedocs`. It runs [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) along with `LiveServer` to render your docs and will track and render any modifications to your docs.
+A function derived from `serve` that will be convenient to Julia package developers is `servedocs`.
+It runs [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) along with `LiveServer` to render your docs and will track and render any modifications to your docs.
 This instantaneous feedback makes writing docs significantly easier and faster.
 
 Assuming you are in `directory/to/YourPackage.jl` and that you have a `docs/` folder as prescribed by `Documenter`, just run:
@@ -66,7 +67,7 @@ julia> servedocs()
 Open a browser and go to `http://localhost:8000/` to see your docs being rendered; try modifying files (e.g. `docs/index.md`) and watch the changes being rendered in the browser.
 
 You can also use LiveServer with both Documenter and [Literate.jl](https://github.com/fredrikekre/Literate.jl).
-This is explained [here](man/ls+lit.md).
+This is explained [here](man/ls+lit/).
 
 ## How it works
 

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -78,5 +78,5 @@ LiveServer.scan_docs!
 
 ```@docs
 LiveServer.example
-LiveServer.setverbose
+LiveServer.set_verbose
 ```

--- a/docs/src/man/ls+lit.md
+++ b/docs/src/man/ls+lit.md
@@ -99,4 +99,4 @@ if you then navigate to `localhost:8000` you should end up with
 
 if you modify `test_dir/docs/literate/man/pg1.jl` for instance writing `f(4)` it will be applied directly:
 
-![](assets/testlit2.png)
+![](/assets/testlit2.png)

--- a/docs/src/man/ls+lit.md
+++ b/docs/src/man/ls+lit.md
@@ -95,8 +95,8 @@ julia> servedocs(literate=joinpath("docs", "literate"))
 
 if you then navigate to `localhost:8000` you should end up with
 
-![](../assets/testlit.png)
+![](/assets/testlit.png)
 
 if you modify `test_dir/docs/literate/man/pg1.jl` for instance writing `f(4)` it will be applied directly:
 
-![](../assets/testlit2.png)
+![](assets/testlit2.png)

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -17,11 +17,11 @@ const BROWSER_RELOAD_SCRIPT = read(joinpath(@__DIR__, "client.html"), String)
 """Whether to display messages while serving or not, see [`verbose`](@ref)."""
 const VERBOSE = Ref{Bool}(false)
 
+"""Whether to display debug messages while serving"""
+const DEBUG = Ref{Bool}(false)
+
 """The folder to watch, either the current one or a specified one (dir=...)."""
 const CONTENT_DIR = Ref{String}("")
-
-"""Relative path to a web dir (from CONTENT_DIR) when the user navigated to one."""
-const WEB_DIR = Ref{String}("")
 
 """List of files being tracked with WebSocket connections."""
 const WS_VIEWERS = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()
@@ -32,9 +32,8 @@ const WS_INTERRUPT = Base.Ref{Bool}(false)
 
 set_content_dir(d::String) = (CONTENT_DIR[] = d;)
 reset_content_dir() = set_content_dir("")
-
-set_web_dir(d::String) = (WEB_DIR[] = d;)
-reset_web_dir() = set_web_dir("")
+set_verbose(b::Bool) = (VERBOSE[] = b;)
+set_debug(b::Bool) = (DEBUG[] = b;)
 
 reset_ws_interrupt() = (WS_INTERRUPT[] = false)
 

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -29,6 +29,15 @@ const WS_VIEWERS = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()
 """Keep track of whether an interruption happened while processing a websocket."""
 const WS_INTERRUPT = Base.Ref{Bool}(false)
 
+
+set_content_dir(d::String) = (CONTENT_DIR[] = d;)
+reset_content_dir() = set_content_dir("")
+
+set_web_dir(d::String) = (WEB_DIR[] = d;)
+reset_web_dir() = set_web_dir("")
+
+reset_ws_interrupt() = (WS_INTERRUPT[] = false)
+
 #
 # Functions
 #

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -1,8 +1,8 @@
 module LiveServer
 
-# from stdlib
-using Sockets, Pkg
-# the only dependency (see the patch in http_patch.jl)
+import Sockets, Pkg, MIMEs
+using Base.Filesystem
+
 using HTTP
 
 export serve, servedocs
@@ -17,8 +17,11 @@ const BROWSER_RELOAD_SCRIPT = read(joinpath(@__DIR__, "client.html"), String)
 """Whether to display messages while serving or not, see [`verbose`](@ref)."""
 const VERBOSE = Ref{Bool}(false)
 
-"""The folder to watch, either the current one or a specified one."""
+"""The folder to watch, either the current one or a specified one (dir=...)."""
 const CONTENT_DIR = Ref{String}("")
+
+"""Relative path to a web dir (from CONTENT_DIR) when the user navigated to one."""
+const WEB_DIR = Ref{String}("")
 
 """List of files being tracked with WebSocket connections."""
 const WS_VIEWERS = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()

--- a/src/file_watching.jl
+++ b/src/file_watching.jl
@@ -186,7 +186,8 @@ end
 
 Checks whether the file specified by `f_path` is being watched.
 """
-is_watched(fw::FileWatcher, f_path::AbstractString) = any(wf -> wf.path == f_path, fw.watchedfiles)
+is_watched(fw::FileWatcher, f_path::AbstractString) =
+    any(wf -> wf.path == f_path, fw.watchedfiles)
 
 
 """

--- a/src/server.jl
+++ b/src/server.jl
@@ -136,9 +136,6 @@ function get_fs_path(req_path::AbstractString)::String
             end
             WEB_DIR[] = cand
         end
-
-        @show WEB_DIR[]
-
         return tmp
     end
 
@@ -150,9 +147,6 @@ function get_fs_path(req_path::AbstractString)::String
         WEB_DIR[],
         lstrip_wdir(joinpath(r_parts...))
     )
-
-    @show fs_path_f
-
     isfile(fs_path_f) && return fs_path_f
 
     #
@@ -333,15 +327,6 @@ function serve_file(
     ret_code = 200
     fs_path  = get_fs_path(target)
 
-    @show req["Host"]
-    @show req["Referer"]
-    @show req.target
-    @show target
-    @show fs_path
-    @show CONTENT_DIR[]
-    @show WEB_DIR[]
-    @show ""
-
     # if get_fs_path returns an empty string, there's two cases:
     # 1. [CASE 3] the path is a directory without an `index.html` --> list dir
     # 2. [CASE 4] otherwise serve a 404 (see if there's a dedicated 404 path,
@@ -354,13 +339,13 @@ function serve_file(
 
         ret_code = 404
         # Check if /404/ or /404.html exists and serve that as a body
-        # for f in ("/404/", "/404.html")
-        #     maybe_path = get_fs_path(f)
-        #     if !isempty(maybe_path)
-        #         fs_path = maybe_path
-        #         break
-        #     end
-        # end
+        for f in ("/404/", "/404.html")
+            maybe_path = get_fs_path(f)
+            if !isempty(maybe_path)
+                fs_path = maybe_path
+                break
+            end
+        end
 
         # If still not found a body, return a generic error message
         if isempty(fs_path)

--- a/src/server.jl
+++ b/src/server.jl
@@ -122,7 +122,7 @@ function get_fs_path(req_path::AbstractString)::String
     )
     if isfile(tmp)
         candrpath = ifelse(append, r_parts[1:end-1], r_parts)
-        WEB_DIR[] = isempty(candrpath) ? "" : joinpath(candrpath...)
+        set_web_dir(isempty(candrpath) ? "" : joinpath(candrpath...))
         return tmp
     end
 
@@ -141,7 +141,7 @@ function get_fs_path(req_path::AbstractString)::String
     # we ensure there's a slash at the end (see also issue #135)
     #
     if isdir(fs_path)
-        WEB_DIR[] = ""
+        reset_web_dir()
         return joinpath(fs_path, "")
     end
 
@@ -500,11 +500,8 @@ directory. (See also [`example`](@ref) for an example folder).
         isdir(dir) || throw(
             ArgumentError("The specified dir '$dir' is not recognised.")
         )
-        CONTENT_DIR[] = dir
+        set_content_dir(dir)
     end
-
-    # Ensure WEB_DIR is always reset
-    WEB_DIR[] = ""
 
     start(fw)
 
@@ -569,9 +566,10 @@ directory. (See also [`example`](@ref) for an example folder).
         empty!(WS_VIEWERS)
         # shut down the server
         HTTP.Servers.forceclose(server)
-        # reset environment variables
-        CONTENT_DIR[]  = ""
-        WS_INTERRUPT[] = false
+        # reset other environment variables
+        reset_content_dir()
+        reset_web_dir()
+        reset_ws_interrupt()
         println("✓")
     end
     return nothing

--- a/src/server.jl
+++ b/src/server.jl
@@ -133,7 +133,7 @@ function get_fs_path(req_path::AbstractString)::String
             cand = ""
             if !isempty(cand_parts)
                 for i in eachindex(cand_parts)
-                    cand = joinpath(string.(cand_parts[1:i]))
+                    cand = joinpath(cand_parts[1:i]...)
                     isfile(joinpath(cand, "index.html")) && break
                 end
             end
@@ -303,7 +303,7 @@ function serve_file(
         host = req["Host"]
         sref = split(req["Referer"], '/')
         idx  = findfirst(x -> x == host, sref)::Int
-        rref = joinpath(string.(sref[idx+1:end]))
+        rref = joinpath(sref[idx+1:end]...)
 
         if startswith(target, rref)
             target = target[nextind(target, length(rref)):end]

--- a/src/server.jl
+++ b/src/server.jl
@@ -133,7 +133,7 @@ function get_fs_path(req_path::AbstractString)::String
             cand = ""
             if !isempty(cand_parts)
                 for i in eachindex(cand_parts)
-                    cand = joinpath(cand_parts[1:i])
+                    cand = joinpath(string.(cand_parts[1:i]))
                     isfile(joinpath(cand, "index.html")) && break
                 end
             end
@@ -303,7 +303,7 @@ function serve_file(
         host = req["Host"]
         sref = split(req["Referer"], '/')
         idx  = findfirst(x -> x == host, sref)::Int
-        rref = joinpath(sref[idx+1:end])
+        rref = joinpath(string.(sref[idx+1:end]))
 
         if startswith(target, rref)
             target = target[nextind(target, length(rref)):end]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -183,6 +183,7 @@ subfolder `docs`.
 """
 function servedocs(;
             verbose::Bool=false,
+            debug::Bool=false,
             literate::Union{Nothing,String}=nothing,
             doc_env::Bool=false,
             skip_dir::String="",
@@ -234,6 +235,7 @@ function servedocs(;
         port=port,
         dir=joinpath(foldername, buildfoldername),
         verbose=verbose,
+        debug=debug,
         launch_browser=launch_browser
     )
 
@@ -246,14 +248,6 @@ end
 #
 # Miscellaneous utils
 #
-
-"""
-    setverbose(b)
-
-Set the verbosity of LiveServer to either `true` (showing messages upon events) or `false` (default).
-"""
-setverbose(b::Bool) = (VERBOSE[] = b)
-
 
 """
     example()

--- a/test/server.jl
+++ b/test/server.jl
@@ -81,6 +81,7 @@ tasks that you will try to start.
     response = HTTP.get("http://localhost:$port/no.html"; status_exception=false)
     @test response.status == 404
     @test occursin("custom 404", String(response.body))
+    LiveServer.WEB_DIR[] = ""
     # if one asks for something without a </body>, it should just be appended
     response = HTTP.get("http://localhost:$port/tmp.html")
     @test response.status == 200

--- a/test/server.jl
+++ b/test/server.jl
@@ -13,10 +13,6 @@
     req = "/test/dummies/?query=string"
     @test LS.get_fs_path(req) == "test/dummies/index.html"
     cd(bk)
-
-    @test LS.append_slash("/a/b") == "/a/b/"
-    @test LS.append_slash("/a/b?c=d") == "/a/b/?c=d"
-    @test LS.append_slash("/a/b/?c=d") == "/a/b/?c=d"
 end
 
 #=

--- a/test/server.jl
+++ b/test/server.jl
@@ -81,7 +81,6 @@ tasks that you will try to start.
     response = HTTP.get("http://localhost:$port/no.html"; status_exception=false)
     @test response.status == 404
     @test occursin("custom 404", String(response.body))
-    LiveServer.WEB_DIR[] = ""
     # if one asks for something without a </body>, it should just be appended
     response = HTTP.get("http://localhost:$port/tmp.html")
     @test response.status == 200

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -164,11 +164,11 @@ end
 end
 
 @testset "Misc utils                  " begin
-    LS.setverbose(false)
+    LS.set_verbose(false)
     @test !LS.VERBOSE.x
-    LS.setverbose(true)
+    LS.set_verbose(true)
     @test LS.VERBOSE.x
-    LS.setverbose(false) # we don't want the tests to show lots of stuff
+    LS.set_verbose(false) # we don't want the tests to show lots of stuff
 
     bk = pwd()
     cd(mktempdir())


### PR DESCRIPTION
After #148 and its problems, I tried to fix this more systematically.

* removed the WEB_DIR stuff which (as per review by @mortenpi) was weird and bad behaviour
* used a proper 301 redirect for directories URL without a trailing slash (thanks @mortenpi) 
* some stuff to "correct" the `request.target` obtained from HTTP in some cases (see below)

### trying this out

all cases mentioned in #135 and #148 (including the CURL stuff) should work, feedback welcome.

Thanks!

closes #135 

### note on target correction

if a html page has `href="/assets/foo.jpg` or `href="assets/foo.jpg"` both should work properly. Now here's two scenarios with different behaviour:

1. (servedocs) on a page `man/ls+lit.md` have `![](...)`, HTTP will set the `req.target` here to `man/ls+lit/assets/foo.jpg` with referer `http://localhost:8000/man/ls+lit/`
2. (serve) on a page similar to the test page from the issue #135 in a folder `lsbox` have a `href="assets/foo.jpg"`, HTTP will set the `req.target` to `lsbox/assets/foo.jpg` with referer `http://localhost:8000/lsbox/` 

in the first case `man/ls+lit/` should be *removed* from the target, in the second case `lsbox/` should *remain* in the target. 

it would be nice if we had access to the root thing before HTTP records a request target and tries to potentially resolve it, so for instance `/assets/foo.jpg` or `assets/foo.jpg` instead of `(something from http)/assets/foo.jpg` which we then have to either remove or keep, but this doesn't seem to be recorded or accessible. 
As a result, there is now some logic in `serve_file` which checks whether the requested target is an existing file, and if it isn't, tries to chop off the head of the path based on the referer to see if that is. If both fail, a 404 is returned.
