### PR TITLE
Add Content_Length header for video type (helps Safari)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/server.jl
+++ b/src/server.jl
@@ -378,7 +378,12 @@ function serve_file(
         end
     end
 
-    headers = ["Content-Type" => content_type]
+    headers = [
+        "Content-Type" => content_type,
+    ]
+    if startswith(content_type, "video/")
+        push!(headers, "Content-Length" => string(stat(fs_path).size))
+    end
 
     if allow_cors
         push!(headers, "Access-Control-Allow-Origin" => "*")


### PR DESCRIPTION
closes #151 

I'll leave this open a few days in case something better comes up to address the issue.

@luraess you can test this works for you by doing `]dev LiveServer#i151`.