### PR TITLE
Also apply dark theme on 404 pages

### DIFF
--- a/src/server.jl
+++ b/src/server.jl
@@ -270,26 +270,28 @@ function pagehtml(f::Base.Callable; title::AbstractString)
     io = IOBuffer()
     # Construct the shared head part of the HTML
     write(io, """
-    <!DOCTYPE HTML>
-    <html>
-      <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/spcss">
-        <title>$(title)</title>
-        <style>
-          a {text-decoration: none;}
-        </style>
-      </head>
-      <body>
-    """)
+        <!DOCTYPE HTML>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/spcss">
+            <title>$(title)</title>
+            <style>
+              a {text-decoration: none;}
+            </style>
+          </head>
+        <body>
+        """
+    )
     # Write the page-specific HTML (should only write the _contents_ of <body>...</body> tag)
     f(io)
     # Write the shared footer
     write(io, """
-      </body>
-    </html>
-    """)
+          </body>
+        </html>
+        """
+    )
     return String(take!(io))
 end
 


### PR DESCRIPTION
After all the issues I've opened, I figured it's finally time for me to contribute back here :smile:  

So the directory listing page, thanks to `spcss`, can automatically detect the system theme, and switch to dark mode. However, `spcss` is not included on 404 pages, so they remain white. This also adds `spcss` to the 404 page, so that those would also be dark.

Since the `<head>` portion of the generated HTML can probably be the same, I opted to to factor the HTML generation into a separate function that generates the head and tail of the HTML, and is re-used for both the 404 page, and also the standard directory listing page. I didn't immediately see anywhere else where I could re-use that function.