### PR TITLE
Getting rid of spurious logging messages from HTTP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,14 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
-authors = [
-  "Jonas Asprion <jonas.asprion@gmx.ch",
-  "Thibaut Lienart <tlienart@me.com>"
-  ]
-version = "1.2.2"
+authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
+version = "1.2.3"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 MIMEs = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 HTTP = "1"

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -2,6 +2,7 @@ module LiveServer
 
 import Sockets, Pkg, MIMEs
 using Base.Filesystem
+using Test: TestLogger
 
 using HTTP
 

--- a/src/server.jl
+++ b/src/server.jl
@@ -606,72 +606,86 @@ current directory. (See also [`example`](@ref) for an example folder).
     # starts the file watcher
     start(fw)
 
-    # make request handler
-    req_handler = HTTP.Handlers.streamhandler() do req
-        req = preprocess_request(req)
-        serve_file(
-            fw, req;
-            inject_browser_reload_script = inject_browser_reload_script,
-            allow_cors = allow_cors
+    # HTTP uses LoggingExtras and, in particular, a @logmsgv which is very
+    # annoying for LiveServer, see https://github.com/JuliaWeb/HTTP.jl/issues/938
+    # as a result we just capture all the logging and discard everything
+    Base.CoreLogging.with_logger(TestLogger()) do
+
+        # make request handler
+        req_handler = HTTP.Handlers.streamhandler() do req
+            req = preprocess_request(req)
+            serve_file(
+                fw, req;
+                inject_browser_reload_script = inject_browser_reload_script,
+                allow_cors = allow_cors
+            )
+        end
+    
+        server, port = get_server(host, port, req_handler)
+        host_str     = ifelse(host == string(Sockets.localhost), "localhost", host)
+        url          = "http://$host_str:$port"
+        println(
+            "✓ LiveServer listening on $url/ ...\n  (use CTRL+C to shut down)"
         )
-    end
 
-    server, port = get_server(host, port, req_handler)
-    host_str     = ifelse(host == string(Sockets.localhost), "localhost", host)
-    url          = "http://$host_str:$port"
-    println(
-        "✓ LiveServer listening on $url/ ...\n  (use CTRL+C to shut down)"
-    )
-
-    launch_browser && open_in_default_browser(url)
-    # wait until user interrupts the LiveServer (using CTRL+C).
-    try
-        counter = 1
-        while true
-            if WS_INTERRUPT[] || fw.status == :interrupted
-                # rethrow the interruption (which may have happened during
-                # the websocket handling or during the file watching)
-                throw(InterruptException())
+        launch_browser && open_in_default_browser(url)
+        # wait until user interrupts the LiveServer (using CTRL+C).
+        try
+            counter = 1
+            while true
+                if WS_INTERRUPT[] || fw.status == :interrupted
+                    # rethrow the interruption (which may have happened during
+                    # the websocket handling or during the file watching)
+                    throw(InterruptException())
+                end
+                
+                sleep(2)
+                try
+                    sqrt(-1)
+                catch e
+                    HTTP.LoggingExtras.@logmsgv 1 HTTP.Logging.Error "I don't want to see this" exception=(e, stacktrace(catch_backtrace()))
+                end
+                
+                # run the auxiliary function if there is one (by default this does
+                # nothing)
+                coreloopfun(counter, fw)
+                # update the cycle counter and sleep (yields to other threads)
+                counter += 1
+                sleep(0.1)
             end
-            # run the auxiliary function if there is one (by default this does
-            # nothing)
-            coreloopfun(counter, fw)
-            # update the cycle counter and sleep (yields to other threads)
-            counter += 1
-            sleep(0.1)
-        end
-    catch err
-        if !isa(err, InterruptException)
-            if VERBOSE[]
-                @error "serve error" exception=(err, catch_backtrace())
+        catch err
+            if !isa(err, InterruptException)
+                if VERBOSE[]
+                    @error "serve error" exception=(err, catch_backtrace())
+                end
+                throw(err)
             end
-            throw(err)
-        end
-    finally
-        # cleanup: close everything that might still be alive
-        print("\n⋮ shutting down LiveServer… ")
-        # stop the filewatcher
-        stop(fw)
-        # close any remaining websockets
-        for wss ∈ values(WS_VIEWERS)
-            @sync for wsi in wss
-                isopen(wsi.io) && @async begin
-                    try
-                        wsi.writeclosed = wsi.readclosed = true
-                        close(wsi.io)
-                    catch
+        finally
+            # cleanup: close everything that might still be alive
+            print("\n⋮ shutting down LiveServer… ")
+            # stop the filewatcher
+            stop(fw)
+            # close any remaining websockets
+            for wss ∈ values(WS_VIEWERS)
+                @sync for wsi in wss
+                    isopen(wsi.io) && @async begin
+                        try
+                            wsi.writeclosed = wsi.readclosed = true
+                            close(wsi.io)
+                        catch
+                        end
                     end
                 end
             end
+            # empty the dictionary of viewers
+            empty!(WS_VIEWERS)
+            # shut down the server
+            HTTP.Servers.forceclose(server)
+            # reset other environment variables
+            reset_content_dir()
+            reset_ws_interrupt()
+            println("✓")
         end
-        # empty the dictionary of viewers
-        empty!(WS_VIEWERS)
-        # shut down the server
-        HTTP.Servers.forceclose(server)
-        # reset other environment variables
-        reset_content_dir()
-        reset_ws_interrupt()
-        println("✓")
     end
     return nothing
 end


### PR DESCRIPTION
This should help with the nuisance caused by https://github.com/JuliaWeb/HTTP.jl/issues/938 where a user may be faced with an obscure error about a broken pipe (EPIPE) which they can't do anything about and, actually, doesn't affect the server.

It should be rolled back in favour of something else if we get a better approach from 938.