### PR TITLE
Finally properly address the annoying HTTP broken pipe stuff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LiveServer"
 uuid = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 authors = ["Jonas Asprion <jonas.asprion@gmx.ch", "Thibaut Lienart <tlienart@me.com>"]
-version = "1.2.4"
+version = "1.2.5"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.2.4"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 MIMEs = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -12,5 +13,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 HTTP = "1"
+LoggingExtras = "1"
 MIMEs = "0.1"
 julia = "1.6"

--- a/src/LiveServer.jl
+++ b/src/LiveServer.jl
@@ -2,8 +2,8 @@ module LiveServer
 
 import Sockets, Pkg, MIMEs
 using Base.Filesystem
-using Test: TestLogger
 using Base.Threads: @spawn
+using LoggingExtras
 
 using HTTP
 
@@ -17,19 +17,19 @@ export serve, servedocs
 const BROWSER_RELOAD_SCRIPT = read(joinpath(@__DIR__, "client.html"), String)
 
 """Whether to display messages while serving or not, see [`verbose`](@ref)."""
-const VERBOSE = Ref{Bool}(false)
+const VERBOSE = Ref(false)
 
 """Whether to display debug messages while serving"""
-const DEBUG = Ref{Bool}(false)
+const DEBUG = Ref(false)
 
 """The folder to watch, either the current one or a specified one (dir=...)."""
-const CONTENT_DIR = Ref{String}("")
+const CONTENT_DIR = Ref("")
 
 """List of files being tracked with WebSocket connections."""
 const WS_VIEWERS = Dict{String,Vector{HTTP.WebSockets.WebSocket}}()
 
 """Keep track of whether an interruption happened while processing a websocket."""
-const WS_INTERRUPT = Base.Ref{Bool}(false)
+const WS_INTERRUPT = Ref(false)
 
 
 set_content_dir(d::String) = (CONTENT_DIR[] = d;)

--- a/src/server.jl
+++ b/src/server.jl
@@ -653,9 +653,6 @@ current directory. (See also [`example`](@ref) for an example folder).
             sleep(0.1)
         end
     catch err
-
-        println("I'm here with $err")
-
         if !isa(err, InterruptException)
             if VERBOSE[]
                 @error "serve error" exception=(err, catch_backtrace())

--- a/src/server.jl
+++ b/src/server.jl
@@ -52,6 +52,7 @@ function update_and_close_viewers!(
     @sync for wsᵢ in ws_to_update_and_close
         isopen(wsᵢ.io) && @spawn begin
             try
+                redirect_stderr()
                 HTTP.WebSockets.send(wsᵢ, "update")
             catch
             end
@@ -63,6 +64,7 @@ function update_and_close_viewers!(
     @sync for wsi in ws_to_update_and_close
         isopen(wsi.io) && @spawn begin
             try
+                redirect_stderr()
                 wsi.writeclosed = wsi.readclosed = true
                 close(wsi.io)
             catch
@@ -616,6 +618,15 @@ current directory. (See also [`example`](@ref) for an example folder).
         )
     end
 
+    old_logger = global_logger()
+    old_stderr = stderr
+    global_logger(
+        EarlyFilteredLogger(
+            log -> log._module !== HTTP.Servers,
+            global_logger()
+        )
+    )
+
     server, port = get_server(host, port, req_handler)
     host_str     = ifelse(host == string(Sockets.localhost), "localhost", host)
     url          = "http://$host_str:$port"
@@ -624,6 +635,7 @@ current directory. (See also [`example`](@ref) for an example folder).
     )
 
     launch_browser && open_in_default_browser(url)
+
     # wait until user interrupts the LiveServer (using CTRL+C).
     try
         counter = 1
@@ -641,6 +653,9 @@ current directory. (See also [`example`](@ref) for an example folder).
             sleep(0.1)
         end
     catch err
+
+        println("I'm here with $err")
+
         if !isa(err, InterruptException)
             if VERBOSE[]
                 @error "serve error" exception=(err, catch_backtrace())
@@ -673,6 +688,11 @@ current directory. (See also [`example`](@ref) for an example folder).
         reset_ws_interrupt()
         println("✓")
     end
+    # given that LiveServer is interrupted via an InterruptException, we have
+    # to be extra careful that things are back as they were before, otherwise
+    # there's a high risk of the disgusting broken pipe error...
+    redirect_stderr(old_stderr)
+    global_logger(old_logger)
     return nothing
 end
 
@@ -694,6 +714,7 @@ function get_server(
     incr >= 10 && @error "couldn't find a free port in $incr tries"
     try
         server = HTTP.listen!(host, port; readtimeout=0, verbose=-1) do http::HTTP.Stream
+            redirect_stderr()
             if HTTP.WebSockets.isupgrade(http.message)
                 # upgrade to websocket and add to list of viewers and keep open
                 # until written to


### PR DESCRIPTION
LoggingExtras and some tweak and it now finally seems to work as expected, hiding these pesky error messages without messing up the rest of the logging.