### PR TITLE
fix infinite loops for custom folder and buildfolder

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -228,7 +228,7 @@ function servedocs(;
     if isempty(skip_dirs) && !isempty(skip_dir)
         skip_dirs = [skip_dir]
     end
-    push!(skip_dirs, joinpath("docs", "build"))
+    push!(skip_dirs, joinpath(foldername, buildfoldername))
     skip_dirs     = abspath.(skip_dirs)
     skip_files    = abspath.(skip_files)
     include_dirs  = abspath.(include_dirs)


### PR DESCRIPTION
Based on the changes in #169 I found that [this line](https://github.com/tlienart/LiveServer.jl/blob/master/src/utils.jl#L231) should probably use the parameters instead of the default `"docs"` and `"build"` values.
Though I am not sure why the above mentioned PR changed the behaviour.

This closes #174.