### PR TITLE
Allow letting the docs build to fail with servedocs()

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,7 +49,14 @@ function servedocs_callback!(
     end
 
     # Run a Documenter pass
-    Main.include(abspath(path2makejl))
+    try
+        Main.include(abspath(path2makejl))
+        dw.status = :runnable
+    catch ex
+        # If there was an error, record it so that an error is displayed to the user
+        dw.status = :documenter_jl_error
+    end
+
     file_changed_callback(fp)
     return
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -49,6 +49,16 @@
     @test length(dw.watchedfiles) == 2
     @test readmake() == 4
 
+    # Modify make.jl to force an error
+    write(makejl, "error()")
+    LS.servedocs_callback!(dw, joinpath("docs", "src", "index.md"), makejl, def...)
+    @test dw.status == :documenter_jl_error
+
+    # Fixing the error should reset the status
+    write(makejl, "42")
+    LS.servedocs_callback!(dw, joinpath("docs", "src", "index.md"), makejl, def...)
+    @test dw.status == :runnable
+
     cd(bk)
 end
 


### PR DESCRIPTION
Previously `servedocs()` would exit whenever the docs failed to build, and it can be annoying to always restart it on errors. Now when building the docs fails a special status will be set on the `SimpleWatcher` which will get `serve_file()` to return a custom error page (which will be reloaded automatically when the docs build again).

This is what the error page looks like:
![image](https://github.com/tlienart/LiveServer.jl/assets/5361518/e5c7c92a-2575-472f-8017-7f0568ad3c86)
